### PR TITLE
lib.rs: make main have no args

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ use riscv::register::{mcause, mstatus};
 
 extern "C" {
     // NOTE `rustc` forces this signature on us. See `src/lang_items.rs`
-    fn main(argc: isize, argv: *const *const u8) -> isize;
+    fn main() -> isize;
 
     // Boundaries of the .bss section
     static mut _ebss: u32;
@@ -257,7 +257,7 @@ pub extern "C" fn start_rust() -> ! {
     // Neither `argc` or `argv` make sense in bare metal context so we
     // just stub them
     unsafe {
-        main(0, ::core::ptr::null());
+        main();
     }
 
     // If `main` returns, then we go into "reactive" mode and simply attend


### PR DESCRIPTION
I'm not sure when this changed, but without this patch the app does not seem to run, and with it the blinky_delay test app works as expected.

This is also how it looks in cortex-m-rt: https://github.com/rust-embedded/cortex-m-rt/blob/6c269f195c9a705162fd912beb952b430cc28336/src/lib.rs#L468

Fixes #5.