### PR TITLE
don't declare _start_rust as a "naked" function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,6 @@
 #![feature(global_asm)]
 #![feature(lang_items)]
 #![feature(linkage)]
-#![feature(naked_functions)]
 #![feature(panic_implementation)]
 #![feature(used)]
 
@@ -232,7 +231,6 @@ _start:
 ///
 /// Zeros bss section, initializes data section and calls main. This function
 /// never returns.
-#[naked]
 #[link_section = ".init.rust"]
 #[export_name = "_start_rust"]
 pub extern "C" fn start_rust() -> ! {


### PR DESCRIPTION
The #[naked] attribute means Rust won't emit instructions to push and
pop a new stack frame. But the assembly routine which calls _start_rust
also doesn't push a new stack frame, so there is no valid stack for this
function.

We probably need a stack frame though, since it's implemented in Rust
and we can't easily ensure that Rust won't try to allocate any local
variables. See #5.